### PR TITLE
Don't use `Exception` as an exception class

### DIFF
--- a/lib/sharepoint-errors.rb
+++ b/lib/sharepoint-errors.rb
@@ -1,0 +1,34 @@
+module Sharepoint
+  class Error < StandardError; end
+
+  class RequestError < Error; end
+  class DataError < Error
+    def initialize data, uri = nil, body = nil
+      @data = data['error']
+      @uri  = uri
+      @body = body
+    end
+
+    def lang         ; @data['message']['lang']  ; end
+    def message      ; @data['message']['value'] ; end
+    def code         ; @data['code'] ; end
+    def uri          ; @uri ; end
+    def request_body ; @body ; end
+  end
+
+  # @deprecated Use DataError instead
+  SPException = DataError
+  deprecate_constant :SPException
+
+  class UnsupportedType < Error
+    attr_accessor :type_name
+
+    def initialize type_name
+      @type_name = type_name
+    end
+
+    def message
+      "unsupported type '#{@type_name}'"
+    end
+  end
+end

--- a/lib/sharepoint-lists.rb
+++ b/lib/sharepoint-lists.rb
@@ -113,7 +113,7 @@ module Sharepoint
         item_id = response['d']['ID']
         @site.query :get, "#{site_url}_api/#{__metadata['id']}/items(#{item_id})"
       else
-        raise Sharepoint::SPException.new response, action, payload
+        raise Sharepoint::DataError.new response, action, payload
       end
     end
 

--- a/lib/sharepoint-session.rb
+++ b/lib/sharepoint-session.rb
@@ -28,12 +28,11 @@ module Sharepoint
   end
 
   class Session
-    class ConnexionToStsFailed < Exception ; end
-    class ConnexionToSharepointFailed < Exception; end
-    class UnknownAuthenticationError  < Exception; end
-    class AuthenticationFailed < Exception
-      def initialize message ; super message ; end
-    end
+    class Error < Sharepoint::Error; end
+    class ConnexionToStsFailed        < Sharepoint::Session::Error; end
+    class ConnexionToSharepointFailed < Sharepoint::Session::Error; end
+    class UnknownAuthenticationError  < Sharepoint::Session::Error; end
+    class AuthenticationFailed        < Sharepoint::Session::Error; end
 
     attr_accessor :site
 

--- a/lib/sharepoint-types.rb
+++ b/lib/sharepoint-types.rb
@@ -1,18 +1,6 @@
 require 'sharepoint-object'
 
 module Sharepoint
-  class UnsupportedType < ::Exception
-    attr_accessor :type_name
-
-    def initialize type_name
-      @type_name = type_name
-    end
-
-    def message
-      "unsupported type '#{@type_name}'"
-    end
-  end
-
   module Type
     def initialize site, data = nil
       data               ||= Hash.new

--- a/sharepoint-ruby.gemspec
+++ b/sharepoint-ruby.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description  = "Client for Sharepoint's REST API"
   s.authors      = ["Michael Martin Moro"]
   s.email        = 'michael@unetresgrossebite.com'
-  s.files        = ['lib/sharepoint-ruby.rb',   'lib/sharepoint-session.rb',
+  s.files        = ['lib/sharepoint-ruby.rb',   'lib/sharepoint-errors.rb', 'lib/sharepoint-session.rb',
                     'lib/sharepoint-object.rb', 'lib/sharepoint-types.rb', 'lib/sharepoint-properties.rb',
                     'lib/sharepoint-users.rb',  'lib/sharepoint-lists.rb', 'lib/sharepoint-files.rb', 'lib/sharepoint-fields.rb',
                     'lib/sharepoint-stringutils.rb',


### PR DESCRIPTION
* Don't use `Exception` for raising exceptions as it cannot be caught specifically without catching all exceptions

* Use a base class for Sharepoint errors so they can be caught more specifically